### PR TITLE
Fix telematics example data in swagger doc

### DIFF
--- a/product-behaviour-twin-libraries/src/main/java/net/catena_x/btp/libraries/oem/backend/datasource/updater/controller/swagger/TelematicsDataAddDoc.java
+++ b/product-behaviour-twin-libraries/src/main/java/net/catena_x/btp/libraries/oem/backend/datasource/updater/controller/swagger/TelematicsDataAddDoc.java
@@ -176,7 +176,7 @@ If the given telematics data are not newer than the last uploaded data, the new 
       }
     }
   ],
-  "adaptionValueList": [
+  "adaptionValues": [
     {
       "status": {
         "date": "2022-11-29T09:16:47.450911100Z",


### PR DESCRIPTION
I received an error when trying to add the sample telematics data from the swagger doc.
I was able to get it to work if I renamed the field name `adaptionValueList` to `adaptionValues`.